### PR TITLE
Refactor provider to its own resource file

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,3 @@
-provider "aws" {
-  alias  = "replica"
-  region = var.replica_region
-}
-
 resource "aws_kms_key" "primary" {
   multi_region             = true
   description              = var.description

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  alias  = "replica"
+  region = var.replica_region
+}


### PR DESCRIPTION
Cannot use current provider w/ AWS profiles, assumed roles, or custom AWS Credentials file in the current configuration. Moving to a separate file allows modifying exactly how the provider is instantiated if needed to leverage end-users workflow